### PR TITLE
Update deployment.md

### DIFF
--- a/concepts/deployment.md
+++ b/concepts/deployment.md
@@ -775,7 +775,7 @@ Deployment也需要 [`.spec` section](https://github.com/kubernetes/community/bl
 
 #### Revision
 
-`.spec.rollbackTo.revision`是一个可选配置项，用来指定回退到的revision。默认是0，意味着回退到历史中最老的revision。
+`.spec.rollbackTo.revision`是一个可选配置项，用来指定回退到的revision。默认是0，意味着回退到上一个revision。
 
 ### Revision History Limit
 


### PR DESCRIPTION
原文“Setting to 0 means rolling back to the last revision in history”。是历史中最新的版本吧。