### PR TITLE
Update introduction/101.md

### DIFF
--- a/introduction/101.md
+++ b/introduction/101.md
@@ -3,7 +3,7 @@
 体验Kubernetes最简单的方法是跑一个nginx容器，然后使用kubectl操作该容器。Kubernetes提供了一个类似于`docker run`的命令`kubectl run`，可以方便的创建一个容器（实际上创建的是一个由deployment来管理的Pod）：
 
 ```sh
-$ kubectl run --image=nginx nginx-app --port=80               
+$ kubectl run --image=nginx:alpine nginx-app --port=80               
 deployment "nginx-app" created                                         
 $ kubectl get pods
 NAME                         READY     STATUS    RESTARTS   AGE
@@ -68,10 +68,33 @@ Events:
   7m   		7m     		1      	{kubelet boot2docker}  	spec.containers{nginx-app}     	Normal 		Created		Created container with docker id 4ef989b57d0a
   7m   		7m     		1      	{kubelet boot2docker}  	spec.containers{nginx-app}     	Normal 		Started		Started container with docker id 4ef989b57d0a
 
+$ curl http://172.17.0.3
+<!DOCTYPE html>
+<html>
+<head>
+<title>Welcome to nginx!</title>
+<style>
+    body {
+        width: 35em;
+        margin: 0 auto;
+        font-family: Tahoma, Verdana, Arial, sans-serif;
+    }
+</style>
+</head>
+<body>
+<h1>Welcome to nginx!</h1>
+<p>If you see this page, the nginx web server is successfully installed and
+working. Further configuration is required.</p>
+<p>For online documentation and support please refer to
+<a href="http://nginx.org/">nginx.org</a>.<br/>
+Commercial support is available at
+<a href="http://nginx.com/">nginx.com</a>.</p>
+<p><em>Thank you for using nginx.</em></p>
+</body>
+</html>
 
 $ kubectl logs nginx-app-4028413181-cnt1i
 127.0.0.1 - - [06/Sep/2016:00:27:13 +0000] "GET / HTTP/1.0 " 200 612 "-" "-" "-"
-127.0.0.1 - - [06/Sep/2016:00:27:15 +0000] "GET / HTTP/1.0 " 200 612 "-" "-" "-"
 ```
 
 ## 使用yaml定义Pod
@@ -174,14 +197,14 @@ Kubernetes volume支持非常多的插件，可以根据实际需要来选择：
 前面虽然创建了Pod，但是在kubernetes中，Pod的IP地址会随着Pod的重启而变化，并不建议直接拿Pod的IP来交互。那如何来访问这些Pod提供的服务呢？使用Service。Service为一组Pod（通过labels来选择）提供一个统一的入口，并为它们提供负载均衡和自动服务发现。比如，可以为前面的`nginx-app`创建一个service：
 
 ```yaml
-$ kubectl expose deployment nginx-app --type=NodePort --port=80 --target-port=80
+$ kubectl expose deployment nginx-app --port=80 --target-port=80
 service "nginx-app" exposed
 $ kubectl describe service nginx-app
 Name:  			nginx-app
 Namespace:     		default
 Labels:			run=nginx-app
 Selector:      		run=nginx-app
-Type:  			NodePort
+Type:  			ClusterIP
 IP:    			10.0.0.66
 Port:  			<unset>	80/TCP
 NodePort:      		<unset>	30772/TCP


### PR DESCRIPTION
1. 目前的 `nginx:latest` 镜像默认没有安装 `procps`，改为 `nginx:alpine` 镜像。
2. `curl http://172.17.0.3` 增加一次请求，以便产生容器日志。
3. `kubectl expose deployment ...` 没有必要使用 `--type=NodePort`，因为并没有设置固定的 nodePort（好像也不能在命令行设置）。