### PR TITLE
Update 201.md

### DIFF
--- a/introduction/201.md
+++ b/introduction/201.md
@@ -37,7 +37,7 @@ kubectl rolling-update frontend-v1 frontend-v2 --image=image:v2
 kubectl rolling-update frontend-v1 frontend-v2 --rollback
 ```
 
-需要注意的是，rolling-update只针对ReplicationController，不能用在策略不是RollingUpdate的Deployment上（Deployment可以在spec中设置更新策略为RollingUpdate，默认就是RollingUpdate）：
+需要注意的是，`kubectl rolling-update`只针对ReplicationController。对于更新策略是RollingUpdate的Deployment（Deployment可以在spec中设置更新策略为RollingUpdate，默认就是RollingUpdate），更新应用后会自动滚动升级：
 
 ```yaml
   spec:
@@ -114,10 +114,10 @@ spec:
 
 ## 健康检查
 
-Kubernetes作为一个面向应用的集群管理工具，需要确保容器在部署后确实处在正常的运行状态。Kubernetes提供了两种探针（Probe，支持exec、tcp和http方式）来探测容器的状态：
+Kubernetes作为一个面向应用的集群管理工具，需要确保容器在部署后确实处在正常的运行状态。Kubernetes提供了两种探针（Probe，支持exec、tcpSocket和http方式）来探测容器的状态：
 
-- LivenessProbe：探测应用是否处于健康状态，如果不健康则删除重建改容器
-- ReadinessProbe：探测应用是否启动完成并且处于正常服务状态，如果不正常则更新容器的状态
+- LivenessProbe：探测应用是否处于健康状态，如果不健康则删除并重新创建容器
+- ReadinessProbe：探测应用是否启动完成并且处于正常服务状态，如果不正常则不会接收来自Kubernetes Service的流量
 
 对于已经部署的deployment，可以通过`kubectl edit deployment/nginx-app`来更新manifest，增加健康检查部分：
 


### PR DESCRIPTION
1. RollingUpdate 描述有些混淆；
2. Probe: tcp 校正为 tcpSocket；
2. ReadinessProbe 描述不太正确，[Define readiness probes](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes#define-readiness-probes)。