### PR TITLE
Fixes word mistake

### DIFF
--- a/plugins/admission.md
+++ b/plugins/admission.md
@@ -29,7 +29,7 @@ Initializers可以用来给资源执行策略或者配置默认选项，包括In
 
 Initializers的开启方法为
 
-- kube-apiserver配置`--admission-control=...,Initializer`
+- kube-apiserver配置`--admission-control=...,Initializers`
 - kube-apiserver开启`admissionregistration.k8s.io/v1alpha1` API，即配置`--runtime-config=admissionregistration.k8s.io/v1alpha1`
 - 部署Initializers控制器
 


### PR DESCRIPTION
page: https://kubernetes.io/docs/admin/extensible-admission-controllers/#initializers

Enable initializers alpha feature
Initializers is an alpha feature, so it is disabled by default. To turn it on, you need to:

Include “Initializers” in the --admission-control flag when starting kube-apiserver. If you have multiple kube-apiserver replicas, all should have the same flag setting.

Enable the dynamic admission controller registration API by adding admissionregistration.k8s.io/v1alpha1 to the --runtime-config flag passed to kube-apiserver, e.g. --runtime-config=admissionregistration.k8s.io/v1alpha1. Again, all replicas should have the same flag setting.