### PR TITLE
Fix: bad kubectl get --raw command

### DIFF
--- a/addons/metrics.md
+++ b/addons/metrics.md
@@ -60,10 +60,10 @@ kubectl -n kube-system get pods -l k8s-app=metrics-server
 
 也可以直接通过 kubectl 命令来访问这些 API，比如
 
-- `kubectl get --raw apis/metrics.k8s.io/v1beta1/nodes`
-- `kubectl get --raw apis/metrics.k8s.io/v1beta1/pods`
-- `kubectl get --raw apis/metrics.k8s.io/v1beta1/nodes/<node-name>`
-- `kubectl get --raw apis/metrics.k8s.io/v1beta1/namespace/<namespace-name>/pods/<pod-name>`
+- `kubectl get --raw /apis/metrics.k8s.io/v1beta1/nodes`
+- `kubectl get --raw /apis/metrics.k8s.io/v1beta1/pods`
+- `kubectl get --raw /apis/metrics.k8s.io/v1beta1/nodes/<node-name>`
+- `kubectl get --raw /apis/metrics.k8s.io/v1beta1/namespace/<namespace-name>/pods/<pod-name>`
 
 ## 排错
 

--- a/en/addons/metrics.md
+++ b/en/addons/metrics.md
@@ -51,10 +51,10 @@ You can access [Metrics API](https://github.com/kubernetes/community/blob/master
 
 Or it can be accessed by kubectl raw:
 
-- `kubectl get --raw apis/metrics.k8s.io/v1beta1/nodes`
-- `kubectl get --raw apis/metrics.k8s.io/v1beta1/pods`
-- `kubectl get --raw apis/metrics.k8s.io/v1beta1/nodes/<node-name>`
-- `kubectl get --raw apis/metrics.k8s.io/v1beta1/namespace/<namespace-name>/pods/<pod-name>`
+- `kubectl get --raw /apis/metrics.k8s.io/v1beta1/nodes`
+- `kubectl get --raw /apis/metrics.k8s.io/v1beta1/pods`
+- `kubectl get --raw /apis/metrics.k8s.io/v1beta1/nodes/<node-name>`
+- `kubectl get --raw /apis/metrics.k8s.io/v1beta1/namespace/<namespace-name>/pods/<pod-name>`
 
 ## Troubleshooting
 


### PR DESCRIPTION
Hi, actually I'm not sure if this is a bad command or not. I got a error when run this command on k8s v1.13.0 cluster.

```
$ kubectl get --raw apis/metrics.k8s.io/v1beta1/nodes
error: --raw must be a valid URL path: parse apis/metrics.k8s.io/v1beta1/nodes: invalid URI for request
See 'kubectl get -h' for help and examples.
```