### PR TITLE
Fix broken link in kube-scheduler

### DIFF
--- a/components/scheduler.md
+++ b/components/scheduler.md
@@ -373,4 +373,4 @@ priorities 策略
 - [Pod Priority and Preemption](https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/)
 - [Configure Multiple Schedulers](https://kubernetes.io/docs/tasks/administer-cluster/configure-multiple-schedulers/)
 - [Taints and Tolerations](https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/)
-- [Advanced Scheduling in Kubernetes](http://blog.kubernetes.io/2017/03/advanced-scheduling-in-kubernetes.html)
+- [Advanced Scheduling in Kubernetes](https://kubernetes.io/blog/2017/03/advanced-scheduling-in-kubernetes/)


### PR DESCRIPTION
The commit fixed broken link in the kube-scheduler page.