### PR TITLE
Fix broken links

### DIFF
--- a/concepts/deployment.md
+++ b/concepts/deployment.md
@@ -608,7 +608,7 @@ $ kubectl patch deployment/nginx-deployment -p '{"spec":{"progressDeadlineSecond
 - Status=False
 - Reason=ProgressDeadlineExceeded
 
-浏览 [Kubernetes API conventions](https://github.com/kubernetes/community/blob/master/contributors/devel/api-conventions.md#typical-status-properties) 查看关于 status conditions 的更多信息。
+浏览 [Kubernetes API conventions](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#typical-status-properties) 查看关于 status conditions 的更多信息。
 
 **注意:** kubernetes 除了报告 `Reason=ProgressDeadlineExceeded` 状态信息外不会对卡住的 Deployment 做任何操作。更高层次的协调器可以利用它并采取相应行动，例如，回滚 Deployment 到之前的版本。
 
@@ -714,7 +714,7 @@ $ echo $?
 
 在所有的 Kubernetes 配置中，Deployment 也需要 `apiVersion`，`kind` 和 `metadata` 这些配置项。配置文件的通用使用说明查看 [部署应用](https://kubernetes.io/docs/tasks/run-application/run-stateless-application-deployment/)，配置容器，和[使用 kubeclt 管理资源](https://kubernetes.io/docs/concepts/overview/working-with-objects/object-management/) 文档。
 
-Deployment 也需要 [`.spec` section](https://github.com/kubernetes/community/blob/master/contributors/devel/api-conventions.md#spec-and-status).
+Deployment 也需要 [`.spec` section](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#spec-and-status).
 
 ### Pod Template
 

--- a/devel/testing.md
+++ b/devel/testing.md
@@ -193,8 +193,8 @@ kubectl get pods nginx-4263166205-ggst4 -o template '--template={{if (exists ."s
 
 ## 参考文档
 
-* [Kubernetes testing](https://github.com/kubernetes/community/blob/master/contributors/devel/testing.md)
-* [End-to-End Testing](https://github.com/kubernetes/community/blob/master/contributors/devel/e2e-tests.md)
-* [Node e2e test](https://github.com/kubernetes/community/blob/master/contributors/devel/e2e-node-tests.md)
-* [How to write e2e test](https://github.com/kubernetes/community/blob/master/contributors/devel/writing-good-e2e-tests.md)
+* [Kubernetes testing](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-testing/testing.md)
+* [End-to-End Testing](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-testing/e2e-tests.md)
+* [Node e2e test](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-node/e2e-node-tests.md)
+* [How to write e2e test](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-testing/writing-good-e2e-tests.md)
 * [Coding Conventions](https://github.com/kubernetes/community/blob/master/contributors/guide/coding-conventions.md)

--- a/practice/service-discovery-lb/network-and-cluster-perfermance-test.md
+++ b/practice/service-discovery-lb/network-and-cluster-perfermance-test.md
@@ -404,6 +404,6 @@ Locust模拟10万用户，每秒增长100个。
 
 [运用Kubernetes进行分布式负载测试](http://www.csdn.net/article/2015-07-07/2825155)
 
-[Kubemark User Guide](https://github.com/kubernetes/community/blob/master/contributors/devel/kubemark-guide.md)
+[Kubemark User Guide](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-scalability/kubemark-guide.md)
 
 [Flannel host-gw architecture](https://docs.openshift.com/container-platform/3.4/architecture/additional_concepts/flannel.html)


### PR DESCRIPTION
Since the [kubernetes/community](https://github.com/kubernetes/community) has grouped files in contributors/devel folder by SIG, all related links here should be updated.
Related discussion here [#3097](https://github.com/kubernetes/community/issues/3097)