### PR TITLE
Update API endpoints

### DIFF
--- a/en/addons/metrics.md
+++ b/en/addons/metrics.md
@@ -47,14 +47,14 @@ You can access [Metrics API](https://github.com/kubernetes/community/blob/master
 - `http://127.0.0.1:8001/apis/metrics.k8s.io/v1beta1/nodes`
 - `http://127.0.0.1:8001/apis/metrics.k8s.io/v1beta1/nodes/<node-name>`
 - `http://127.0.0.1:8001/apis/metrics.k8s.io/v1beta1/pods`
-- `http://127.0.0.1:8001/apis/metrics.k8s.io/v1beta1/namespace/<namespace-name>/pods/<pod-name>`
+- `http://127.0.0.1:8001/apis/metrics.k8s.io/v1beta1/namespaces/<namespace-name>/pods/<pod-name>`
 
 Or it can be accessed by kubectl raw:
 
 - `kubectl get --raw /apis/metrics.k8s.io/v1beta1/nodes`
 - `kubectl get --raw /apis/metrics.k8s.io/v1beta1/pods`
 - `kubectl get --raw /apis/metrics.k8s.io/v1beta1/nodes/<node-name>`
-- `kubectl get --raw /apis/metrics.k8s.io/v1beta1/namespace/<namespace-name>/pods/<pod-name>`
+- `kubectl get --raw /apis/metrics.k8s.io/v1beta1/namespaces/<namespace-name>/pods/<pod-name>`
 
 ## Troubleshooting
 


### PR DESCRIPTION
In Kubernetes 1.13 I get the following error querying metrics using the paths documented here:

```
$ kubectl get --raw /apis/metrics.k8s.io/v1beta1/namespace/default/pods/busybox
Error from server (NotFound): the server could not find the requested resource
```

Changing `namespace` to `namespaces` fixes the error: 

```
$ kubectl get --raw /apis/metrics.k8s.io/v1beta1/namespaces/default/pods/busybox | jq
{
  "kind": "PodMetrics",
  "apiVersion": "metrics.k8s.io/v1beta1",
  "metadata": {
    "name": "busybox",
    "namespace": "default",
    "selfLink": "/apis/metrics.k8s.io/v1beta1/namespaces/default/pods/busybox",
    "creationTimestamp": "2019-10-04T23:44:05Z"
  },
  "timestamp": "2019-10-04T23:43:45Z",
  "window": "30s",
  "containers": [
    {
      "name": "busybox",
      "usage": {
        "cpu": "0",
        "memory": "340Ki"
      }
    }
  ]
}
```