### PR TITLE
Fix concepts/pod.md

### DIFF
--- a/concepts/pod.md
+++ b/concepts/pod.md
@@ -1,18 +1,24 @@
 # Pod
 
-Pod 是一组紧密关联的容器集合，它们共享 IPC、Network 和 PID namespace，是 Kubernetes 调度的基本单位。Pod 的设计理念是支持多个容器在一个 Pod 中共享网络和文件系统，可以通过进程间通信和文件共享这种简单高效的方式组合完成服务。
+Pod 是一组紧密关联的容器集合，它们共享 IPC 和 Network namespace，是 Kubernetes 调度的基本单位。Pod 的设计理念是支持多个容器在一个 Pod 中共享网络和文件系统，可以通过进程间通信和文件共享这种简单高效的方式组合完成服务。
 
 ![pod](images/pod.png)
 
 Pod 的特征
 
-- 包含多个共享 IPC、Network 和 UTC namespace 的容器，可直接通过 localhost 通信
+- 包含多个共享 IPC 和 Network namespace 的容器，可直接通过 localhost 通信
 - 所有 Pod 内容器都可以访问共享的 Volume，可以访问共享数据
 - 无容错性：直接创建的 Pod 一旦被调度后就跟 Node 绑定，即使 Node 挂掉也不会被重新调度（而是被自动删除），因此推荐使用 Deployment、Daemonset 等控制器来容错
 - 优雅终止：Pod 删除的时候先给其内的进程发送 SIGTERM，等待一段时间（grace period）后才强制停止依然还在运行的进程
 - 特权容器（通过 SecurityContext 配置）具有改变系统配置的权限（在网络插件中大量应用）
 
-> Kubernetes v1.8+ 还支持容器间共享 PID namespace，需要 docker >= 1.13.1，并配置 kubelet `--docker-disable-shared-pid=false`。
+> Kubernetes v1.8+ 支持容器间共享 PID namespace，需要 docker >= 1.13.1，并配置 kubelet `--docker-disable-shared-pid=false`。
+
+> 在 Kubernetes v1.10+ `--docker-disable-shared-pid` 已被弃用，如果要共享 PID namespace，需要设置 v1.PodSpec 中的 ShareProcessNamespace 为 true，如下所示
+```yaml
+spec:
+  shareProcessNamespace: true
+```
 
 ## API 版本对照表
 


### PR DESCRIPTION
1. Containers in a pod don't share PID namespace unless `shareProcessNamespace` is true , see https://kubernetes.io/docs/tasks/configure-pod-container/share-process-namespace/
2. The --docker-disable-shared-pid flag has been deprecated since 1.10 , see https://github.com/kubernetes/kubernetes/pull/66506