### PR TITLE
Fix Metrics API

### DIFF
--- a/concepts/components/kubectl.md
+++ b/concepts/components/kubectl.md
@@ -328,7 +328,7 @@ kubectl 也可以用来直接访问原始 URI，比如要访问 [Metrics API](ht
 * `kubectl get --raw /apis/metrics.k8s.io/v1beta1/nodes`
 * `kubectl get --raw /apis/metrics.k8s.io/v1beta1/pods`
 * `kubectl get --raw /apis/metrics.k8s.io/v1beta1/nodes/<node-name>`
-* `kubectl get --raw /apis/metrics.k8s.io/v1beta1/namespace/<namespace-name>/pods/<pod-name>`
+* `kubectl get --raw /apis/metrics.k8s.io/v1beta1/namespaces/<namespace-name>/pods/<pod-name>`
 
 ## 附录
 

--- a/setup/addon-list/metrics.md
+++ b/setup/addon-list/metrics.md
@@ -56,14 +56,14 @@ kubectl -n kube-system get pods -l k8s-app=metrics-server
 * `http://127.0.0.1:8001/apis/metrics.k8s.io/v1beta1/nodes`
 * `http://127.0.0.1:8001/apis/metrics.k8s.io/v1beta1/nodes/<node-name>`
 * `http://127.0.0.1:8001/apis/metrics.k8s.io/v1beta1/pods`
-* `http://127.0.0.1:8001/apis/metrics.k8s.io/v1beta1/namespace/<namespace-name>/pods/<pod-name>`
+* `http://127.0.0.1:8001/apis/metrics.k8s.io/v1beta1/namespaces/<namespace-name>/pods/<pod-name>`
 
 也可以直接通过 kubectl 命令来访问这些 API，比如
 
 * `kubectl get --raw /apis/metrics.k8s.io/v1beta1/nodes`
 * `kubectl get --raw /apis/metrics.k8s.io/v1beta1/pods`
 * `kubectl get --raw /apis/metrics.k8s.io/v1beta1/nodes/<node-name>`
-* `kubectl get --raw /apis/metrics.k8s.io/v1beta1/namespace/<namespace-name>/pods/<pod-name>`
+* `kubectl get --raw /apis/metrics.k8s.io/v1beta1/namespaces/<namespace-name>/pods/<pod-name>`
 
 ## 排错
 


### PR DESCRIPTION
Change `namespace` to `namespaces`, see https://github.com/kubernetes/community/blob/master/contributors/design-proposals/instrumentation/resource-metrics-api.md#endpoints

The same as #212