### PR TITLE
add `--` after exec command

### DIFF
--- a/introduction/101.md
+++ b/introduction/101.md
@@ -22,7 +22,7 @@ $ kubectl get pods
 NAME                         READY     STATUS    RESTARTS   AGE
 nginx-app-4028413181-cnt1i   1/1       Running   0          6m
 
-$ kubectl exec nginx-app-4028413181-cnt1i ps aux
+$ kubectl exec nginx-app-4028413181-cnt1i -- ps aux
 USER       PID %CPU %MEM    VSZ   RSS TTY      STAT START   TIME COMMAND
 root         1  0.0  0.5  31736  5108 ?        Ss   00:19   0:00 nginx: master process nginx -g daemon off;
 nginx        5  0.0  0.2  32124  2844 ?        S    00:19   0:00 nginx: worker process


### PR DESCRIPTION
kubectl exec [POD] [COMMAND] is DEPRECATED and will be removed in a future version. Use kubectl exec [POD] -- [COMMAND] instead.